### PR TITLE
Increase precision about service names

### DIFF
--- a/draft-ietf-add-svcb-dns.md
+++ b/draft-ietf-add-svcb-dns.md
@@ -47,13 +47,15 @@ when, and only when, they appear in all capitals, as shown here.
 
 # Name form
 
-Names are formed using Port-Prefix Naming ({{Section 2.3 of SVCB}}), with a scheme of "dns".  For example, SVCB records for a DNS service identified as "`dns1.example.com`" would be located at "`_dns.dns1.example.com`".
+In this specification, DNS services are identified by a "binding authority" (which MUST be an "`authority`" as in {{Section 3.2 of !RFC3986}}) and an "authentication name" (which MUST be a "`host`" as in {{Section 3.2.2 of !RFC3986}})).  Unless otherwise specified, the authentication name is the Host from the binding authority.
+
+SVCB record names (i.e. QNAMEs) are formed from the binding authority using Port-Prefix Naming ({{Section 2.3 of SVCB}}), with a scheme of "dns".  For example, if the "binding authority" is "`dns1.example.com`", the client would query for SVCB records at "`_dns.dns1.example.com`".
 
 ## Special case: non-default ports
 
 Normally, a DNS service is identified by an IP address or a domain name.  When connecting to the service using unencrypted DNS over UDP or TCP, clients use the default port number for DNS (53).  However, in rare cases, a DNS service might be identified by both a name and a port number.  For example, the `dns:` URI scheme {{?DNSURI=RFC4501}} optionally includes an authority, comprised of a host and a port number (with a default of 53).  DNS URIs normally omit the authority, or specify an IP address, but a hostname and non-default port number are allowed.
 
-When a non-default port number is part of a service identifier, Port-Prefix Naming places the port number in an additional a prefix on the name.  For example, SVCB records for a DNS service identified as "`dns1.example.com:9953`" would be located at "`_9953._dns.dns1.example.com`".  If two DNS services operating on different port numbers provide different behaviors, this arrangement allows them to preserve the distinction when specifying alternative endpoints.
+When a non-default port number is part of the binding authority, Port-Prefix Naming places the port number in an additional a prefix on the name.  For example, if the binding authority is "`dns1.example.com:9953`", the client would query for SVCB records at "`_9953._dns.dns1.example.com`".  If two DNS services operating on different port numbers provide different behaviors, this arrangement allows them to preserve the distinction when specifying alternative endpoints.
 
 # Applicable existing SvcParamKeys
 
@@ -85,7 +87,7 @@ Future SvcParamKeys may also be applicable.
 
 ## dohpath {#dohpath}
 
-"dohpath" is a single-valued SvcParamKey whose value (both in presentation and wire format) is a relative URI Template {{!RFC6570}}, normally starting with "/".  If the "alpn" SvcParamKey indicates support for HTTP, clients MAY construct a DNS over HTTPS URI Template by combining the prefix "https://", the service name, the port from the "port" key if present, and the "dohpath" value.  (The DNS service's original port number MUST NOT be used.)
+"dohpath" is a single-valued SvcParamKey whose value (both in presentation and wire format) is a relative URI Template {{!RFC6570}}, normally starting with "/".  If the "alpn" SvcParamKey indicates support for HTTP, clients MAY construct a DNS over HTTPS URI Template by combining the prefix "https://", the authentication name, the port from the "port" key if present, and the "dohpath" value.  (The binding authority's port number MUST NOT be used.)
 
 Clients SHOULD NOT query for any "HTTPS" RRs when using the constructed URI Template.  Instead, the SvcParams and address records associated with this SVCB record SHOULD be used for the HTTPS connection, with the same semantics as an HTTPS RR.  However, for consistency, service operators SHOULD publish an equivalent HTTPS RR, especially if clients might learn this URI Template through a different channel.
 
@@ -125,7 +127,7 @@ This document is concerned exclusively with the DNS transport, and does not affe
 
 This section considers an adversary who can add or remove responses to the SVCB query.
 
-Clients MUST authenticate the server to its name during secure transport establishment.  This name is the hostname used to construct the original SVCB query, and cannot be influenced by the SVCB record contents.  Accordingly, this draft does not mandate the use of DNSSEC.  This draft also does not specify how clients authenticate the name (e.g. selection of roots of trust), which might vary according to the context.
+During secure transport establishment, clients MUST authenticate the server to its authentication name, which is not influenced by the SVCB record contents.  Accordingly, this draft does not mandate the use of DNSSEC.  This draft also does not specify how clients authenticate the name (e.g. selection of roots of trust), which might vary according to the context.
 
 Although this adversary cannot alter the authentication name of the service, it does have control of the port number and "dohpath" value.  As a result, the adversary can direct DNS queries for $HOSTNAME to any port on $HOSTNAME, and any path on "https://$HOSTNAME", even if $HOSTNAME is not actually a DNS server.  If the DNS client uses shared TLS or HTTP state, the client could be correctly authenticated (e.g. using a TLS client certificate or HTTP cookie).
 


### PR DESCRIPTION
This should help with the `resolver.arpa` case in DDR.
See https://github.com/ietf-wg-add/draft-ietf-add-ddr/issues/41